### PR TITLE
Fix handle problem

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -225,18 +225,16 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     handleEnd = () => {
-      const {distance} = this.props;
-
       this._touched = false;
-
-      if (!distance) {
-        this.cancel();
-      }
+      this.cancel();
     };
 
     cancel = () => {
+      const { distance } = this.props;
       if (!this.state.sorting) {
-        clearTimeout(this.pressTimer);
+        if (!distance) {
+          clearTimeout(this.pressTimer);
+        }
         this.manager.active = null;
       }
     };

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -230,8 +230,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     cancel = () => {
-      const { distance } = this.props;
-      if (!this.state.sorting) {
+      const {distance} = this.props;
+      const {sorting} = this.state;
+
+      if (!sorting) {
         if (!distance) {
           clearTimeout(this.pressTimer);
         }


### PR DESCRIPTION
I found a problem when you set a distance and you have a `SortableHandle`.
After a click on the handle, you are able to drag the element from everywhere inside the `li`.

### Before 
![2018-11-20 19 39 58](https://user-images.githubusercontent.com/4728325/48811535-3cc11280-ecfc-11e8-87ea-4496b6426cfb.gif)

### After
![2018-11-20 19 42 48](https://user-images.githubusercontent.com/4728325/48811957-18fecc00-ecfe-11e8-87e5-64f2b935e862.gif)


So the main problem come from [here](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L179). During the handleStart we set the manager.
But inside the `handleEnd` we never unset the manager if you have set a distance. You can check the code [here](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L227). It true that we shouldn't call `clearTimeout(this.pressTimer);` when you have set a distance because you can't set both properties. 

I found 3 solutions: 
1. Always call cancel after the handleEnd 
2. Move  ```this.manager.active = null;``` inside the `handleEnd` function
3. Since `this.cancel` is only use inside `handleEnd` we can merge both method like that: 
```js
handleEnd = () => {
  const {distance} = this.props;

  this._touched = false;
  
  if (!this.state.sorting) {
    if (!distance) {
      clearTimeout(this.pressTimer);
    }
    this.manager.active = null;
  }
};
```

I choose the solution 3 but I would like your feedback before I create a PR in your repo.

Thanks ✌️ 